### PR TITLE
don't call .capitalize on the endpoint class name

### DIFF
--- a/moltin/moltin.py
+++ b/moltin/moltin.py
@@ -72,17 +72,15 @@ class Moltin:
         self.authenticator = Authenticator(client_id, client_secret, self.request, TokenContainer())
 
     def __getattr__(self, name):
-        obj_name = name.capitalize()
-
-        if obj_name in self.endpoints:
-            e = create_endpoint_object(obj_name, Endpoint)
-            endpoint = e(self.request, self.endpoints[obj_name])
-        elif obj_name in self.custom_endpoints:
-            obj_base, endpoint_name = self.custom_endpoints[obj_name]
+        if name in self.endpoints:
+            e = create_endpoint_object(name, Endpoint)
+            endpoint = e(self.request, self.endpoints[name])
+        elif name in self.custom_endpoints:
+            obj_base, endpoint_name = self.custom_endpoints[name]
             endpoint = curry(obj_base, self.request, endpoint_name)
-        elif obj_name in self.custom_endpoints_without_extra_params:
-            obj_base, endpoint_name = self.custom_endpoints_without_extra_params[obj_name]
-            e = create_endpoint_object(obj_name, obj_base)
+        elif name in self.custom_endpoints_without_extra_params:
+            obj_base, endpoint_name = self.custom_endpoints_without_extra_params[name]
+            e = create_endpoint_object(name, obj_base)
             endpoint = e(self.request, endpoint_name)
         else:
             raise RuntimeError("No such API object: " + name)


### PR DESCRIPTION
This way the product endpoint is only available via the name supplied in the endpoints attribute:

``` python
m = Moltin(client_id, client_secret)
m.Product
# <moltin.moltin.Product object at 0x1026651d0>
m.pRoduct
# before this PR:  <moltin.moltin.Product object at 0x10245cb70>
# after: RuntimeError: No such API object: pRoduct
```

This also will remove the problem that you will run into if you ever add an endpoint with a multi_word name, because `'MutliWord'.capitalize` returns `'Multiword'`
